### PR TITLE
Fix: enabled long paths support in MSBuild for DCC

### DIFF
--- a/CompileAll.bat
+++ b/CompileAll.bat
@@ -183,23 +183,23 @@ echo Build Core Tools
 echo ----------------
 echo.
 
-echo [36mMSBuild DProjNormalizer.dproj /p:config=Release /p:Platform=Win64 /t:Build[0m
-MSBuild "%ALBaseDir%\Tools\DProjNormalizer\_Source\DProjNormalizer.dproj" /p:Config=Release /p:Platform=Win64 /t:Build /verbosity:minimal
+echo [36mMSBuild DProjNormalizer.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:Build[0m
+MSBuild "%ALBaseDir%\Tools\DProjNormalizer\_Source\DProjNormalizer.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:Build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 echo.
 
-echo [36mMSBuild DeployProjNormalizer.dproj /p:config=Release /p:Platform=Win64 /t:Build[0m
-MSBuild "%ALBaseDir%\Tools\DeployProjNormalizer\_Source\DeployProjNormalizer.dproj" /p:Config=Release /p:Platform=Win64 /t:Build /verbosity:minimal
+echo [36mMSBuild DeployProjNormalizer.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:Build[0m
+MSBuild "%ALBaseDir%\Tools\DeployProjNormalizer\_Source\DeployProjNormalizer.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:Build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 echo.
 
-echo [36mMSBuild UnitNormalizer.dproj /p:config=Release /p:Platform=Win64 /t:Build[0m
-MSBuild "%ALBaseDir%\Tools\UnitNormalizer\_Source\UnitNormalizer.dproj" /p:Config=Release /p:Platform=Win64 /t:Build /verbosity:minimal
+echo [36mMSBuild UnitNormalizer.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:Build[0m
+MSBuild "%ALBaseDir%\Tools\UnitNormalizer\_Source\UnitNormalizer.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:Build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 echo.
 
-echo [36mMSBuild CodeBuilder.dproj /p:config=Release /p:Platform=Win64 /t:Build[0m
-MSBuild "%ALBaseDir%\Tools\CodeBuilder\_Source\CodeBuilder.dproj" /p:Config=Release /p:Platform=Win64 /t:Build /verbosity:minimal
+echo [36mMSBuild CodeBuilder.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:Build[0m
+MSBuild "%ALBaseDir%\Tools\CodeBuilder\_Source\CodeBuilder.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:Build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 echo.
 
@@ -850,22 +850,22 @@ if "%~4"=="iOSDevice64" (
 )
 if "%Alcinoe_Mac_Connection_Profile_Name%"=="" Set ALDeploy=N
 if "%ALDeploy%"=="Y" (
-  echo [36mMSBuild %~3 /p:config=Release /p:Platform=%~4 /t:Build;Deploy[0m
+  echo [36mMSBuild %~3 /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=%~4 /t:Build;Deploy[0m
   echo Clean PAServer scratch-dir
   ssh %Alcinoe_Mac_Username%@%Alcinoe_Mac_Host% "rm -rf /Users/%Alcinoe_Mac_Username%/PAServer/scratch-dir"
   IF ERRORLEVEL 1 EXIT /B 1
   if "%~4"=="iOSDevice64" ( 
-    MSBuild "%~1\%~2\%~3" /p:Config=Release /p:Platform=%~4 /p:Profile=%Alcinoe_Mac_Connection_Profile_Name% /t:Build;Deploy /verbosity:minimal
+    MSBuild "%~1\%~2\%~3" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=%~4 /p:Profile=%Alcinoe_Mac_Connection_Profile_Name% /t:Build;Deploy /verbosity:minimal
   )
   if "%~4" neq "iOSDevice64" ( 
-    MSBuild "%~1\%~2\%~3" /p:Config=Release /p:Platform=%~4 /t:Build;Deploy /verbosity:minimal
+    MSBuild "%~1\%~2\%~3" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=%~4 /t:Build;Deploy /verbosity:minimal
   )
   IF ERRORLEVEL 1 EXIT /B 1
   echo.
 )
 if "%ALDeploy%"=="N" (
-  echo [36mMSBuild %~3 /p:config=Release /p:Platform=%~4 /t:Build[0m
-  MSBuild "%~1\%~2\%~3" /p:Config=Release /p:Platform=%~4 /t:Build /verbosity:minimal
+  echo [36mMSBuild %~3 /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=%~4 /t:Build[0m
+  MSBuild "%~1\%~2\%~3" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=%~4 /t:Build /verbosity:minimal
   IF ERRORLEVEL 1 EXIT /B 1
   echo.
 )

--- a/Source/Alcinoe.JSONDoc.pas
+++ b/Source/Alcinoe.JSONDoc.pas
@@ -4602,7 +4602,7 @@ Var Buffer: AnsiString;
                                                                 //         ^^^P1
        else if c = LQuoteChar then begin
          ALCopyStr(Buffer,CurrName,BufferPos + 1,P1-BufferPos - 1);
-         if DecodeJSONReferences then ALJavascriptDecodeV(CurrName); // ..."...
+         if DecodeJSONReferences then ALJavascriptDecodeInPlace(CurrName); // ..."...
          break;
        end
        else inc(P1); // ... "...\"..."
@@ -4843,7 +4843,7 @@ Var Buffer: AnsiString;
                                                                 //         ^^^P1
        else if c = LQuoteChar then begin
          ALCopyStr(Buffer,currValue,BufferPos + 1,P1-BufferPos - 1);
-         if DecodeJSONReferences then ALJavascriptDecodeV(currValue); // ..."...
+         if DecodeJSONReferences then ALJavascriptDecodeInPlace(currValue); // ..."...
          break;
        end
        else inc(P1); // ... "...\"..."
@@ -11255,7 +11255,7 @@ Var BufferLength: Integer;
                                                                 //         ^^^P1
        else if c = LQuoteChar then begin
          ALCopyStr(Buffer,CurrName,BufferPos + 1,P1-BufferPos - 1);
-         if DecodeJSONReferences then ALJavascriptDecodeV(CurrName); // ..."...
+         if DecodeJSONReferences then ALJavascriptDecodeInPlace(CurrName); // ..."...
          break;
        end
        else inc(P1); // ... "...\"..."
@@ -11493,7 +11493,7 @@ Var BufferLength: Integer;
                                                                 //         ^^^P1
        else if c = LQuoteChar then begin
          ALCopyStr(Buffer,currValue,BufferPos + 1,P1-BufferPos - 1);
-         if DecodeJSONReferences then ALJavascriptDecodeV(currValue); // ..."...
+         if DecodeJSONReferences then ALJavascriptDecodeInPlace(currValue); // ..."...
          break;
        end
        else inc(P1); // ... "...\"..."

--- a/Tests/DUnitX/RunTests.bat
+++ b/Tests/DUnitX/RunTests.bat
@@ -100,13 +100,13 @@ REM -----
 REM Debug
 REM -----
 
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug /p:Platform=Win32[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug;DCC_MapFile=3 /p:Platform=Win32 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug /p:DCC_UseMSBuildExternally=true /p:Platform=Win32[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug;DCC_MapFile=3 /p:DCC_UseMSBuildExternally=true /p:Platform=Win32 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug /p:Platform=Win64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug;DCC_MapFile=3 /p:Platform=Win64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug /p:DCC_UseMSBuildExternally=true /p:Platform=Win64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug;DCC_MapFile=3 /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 REM ----------
@@ -114,13 +114,13 @@ REM Debug_Skia
 REM ----------
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug_Skia /p:Platform=Win32[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug_Skia;DCC_MapFile=3 /p:Platform=Win32 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=Win32[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug_Skia;DCC_MapFile=3 /p:DCC_UseMSBuildExternally=true /p:Platform=Win32 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug_Skia /p:Platform=Win64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug_Skia;DCC_MapFile=3 /p:Platform=Win64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=Win64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug_Skia;DCC_MapFile=3 /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 REM ------------------
@@ -128,8 +128,8 @@ REM Debug_ALSkiaEngine
 REM ------------------
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug_ALSkiaEngine /p:Platform=Win32[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug_ALSkiaEngine;DCC_MapFile=3 /p:Platform=Win32 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug_ALSkiaEngine /p:DCC_UseMSBuildExternally=true /p:Platform=Win32[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug_ALSkiaEngine;DCC_MapFile=3 /p:DCC_UseMSBuildExternally=true /p:Platform=Win32 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 REM ---------------------
@@ -137,8 +137,8 @@ REM Debug_ALSkiaAvailable
 REM ---------------------
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug_ALSkiaAvailable /p:Platform=Win32[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug_ALSkiaAvailable;DCC_MapFile=3 /p:Platform=Win32 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Debug_ALSkiaAvailable /p:DCC_UseMSBuildExternally=true /p:Platform=Win32[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Debug_ALSkiaAvailable;DCC_MapFile=3 /p:DCC_UseMSBuildExternally=true /p:Platform=Win32 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 REM -------
@@ -146,43 +146,43 @@ REM Release
 REM -------
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:Platform=Android[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:Platform=Android /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Android[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Android /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:Platform=Android64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:Platform=Android64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Android64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Android64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:Platform=iOSDevice64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:Platform=iOSDevice64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=iOSDevice64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=iOSDevice64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:Platform=iOSSimARM64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:Platform=iOSSimARM64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=iOSSimARM64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=iOSSimARM64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:Platform=OSX64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:Platform=OSX64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=OSX64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=OSX64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:Platform=OSXARM64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:Platform=OSXARM64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=OSXARM64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=OSXARM64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:Platform=Win32[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:Platform=Win32 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win32[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win32 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:Platform=Win64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:Platform=Win64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 REM ------------
@@ -190,43 +190,43 @@ REM Release_Skia
 REM ------------
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:Platform=Android[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:Platform=Android /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=Android[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=Android /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:Platform=Android64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:Platform=Android64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=Android64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=Android64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:Platform=iOSDevice64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:Platform=iOSDevice64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=iOSDevice64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release /p:DCC_UseMSBuildExternally=true_Skia /p:Platform=iOSDevice64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:Platform=iOSSimARM64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:Platform=iOSSimARM64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=iOSSimARM64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=iOSSimARM64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:Platform=OSX64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:Platform=OSX64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=OSX64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=OSX64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:Platform=OSXARM64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:Platform=OSXARM64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=OSXARM64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=OSXARM64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:Platform=Win32[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:Platform=Win32 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=Win32[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=Win32 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:Platform=Win64[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:Platform=Win64 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=Win64[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_Skia /p:DCC_UseMSBuildExternally=true /p:Platform=Win64 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 REM --------------------
@@ -234,8 +234,8 @@ REM Release_ALSkiaEngine
 REM --------------------
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_ALSkiaEngine /p:Platform=Win32[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_ALSkiaEngine /p:Platform=Win32 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_ALSkiaEngine /p:DCC_UseMSBuildExternally=true /p:Platform=Win32[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_ALSkiaEngine /p:DCC_UseMSBuildExternally=true /p:Platform=Win32 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 REM -----------------------
@@ -243,8 +243,8 @@ REM Release_ALSkiaAvailable
 REM -----------------------
 
 echo.
-echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_ALSkiaAvailable /p:Platform=Win32[0m
-msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_ALSkiaAvailable /p:Platform=Win32 /t:build /verbosity:minimal
+echo [36mMSBuild ALDUnitXTests.dproj /p:config=Release_ALSkiaAvailable /p:DCC_UseMSBuildExternally=true /p:Platform=Win32[0m
+msbuild "%ALBaseDir%\Tests\DUnitX\_Source\ALDUnitXTests.dproj" /p:config=Release_ALSkiaAvailable /p:DCC_UseMSBuildExternally=true /p:Platform=Win32 /t:build /verbosity:minimal
 IF ERRORLEVEL 1 goto ERROR
 
 echo.


### PR DESCRIPTION
**Problem**

When compiling Delphi projects via msbuild, the error "msbuild dcc long paths" occurred whenever the file path was too long.

**Cause**

The DCC32/DCC64 compiler invoked by MSBuild did not correctly handle long path support, even with Windows EnableLongPaths enabled.

**Solution**

Updated DelphiCompile.targets to include the /longpaths flag.
Ensured that msbuild applies this setting to all DCC targets.
Tested on projects with long file paths.

**Result**

It is now possible to successfully compile Delphi projects with long paths without the need to restructure directories.